### PR TITLE
feat: add option to deploy app via Ansible automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,12 @@ This application is made up of a frontend with source code [here](https://github
 3. Access to the OpenShift command line interface (CLI) or web console
 
 ## Procedure
+- This document will walk you through a manual deployment below, following a step-by-step procedure. 
+- If you instead would like to deploy the application via web console or via automation:
+    - Alternate Methods:
+        - Web console, see the [Troubleshooting Section](#i-dont-have-access-to-the-oc-cli--i-dont-know-how-to-use-the-oc-cli) below.
+        - If you want to use an Ansible-automated deployment, see the [instructions](#automate-the-deployment-for-me) below:
 
-Note: if you want to use the OpenShift web console to deploy the application instead, see the [Troubleshooting Section](#i-dont-have-access-to-the-oc-cli--i-dont-know-how-to-use-the-oc-cli) below.
 
 1. Create a new project in OpenShift, for example `national-parks`
 
@@ -153,3 +157,16 @@ You can deploy this application via the OpenShift web console.
 You should now see the National Parks map with US locations loaded.
 
 ![national-parks-loaded-home](https://raw.githubusercontent.com/mmondics/media/main/images/national-parks-loaded-home.png)
+
+### Automate the deployment for me
+- Open a command-line prompt and SSH to your cluster's bastion server. 
+- For example on a Mac/Linux machine that would look like this:
+```
+ssh <username>@<ip-address>
+```
+- It will ask you for a password, type it in and hit Enter. 
+- Then, execute the following command:
+```
+sudo dnf install git -y && git clone https://github.com/mmondics/national-parks.git && cd national-parks && sh deploy.sh
+```
+- The instructions at the end of the process will tell you how to display your application.

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,6 @@
 sudo dnf install python3 redhat-rpm-config gcc libffi-devel python3-devel openssl-devel cargo pkg-config -y
-python3 -m pip3 install cryptography --no-binary --ignore-installed cryptography
-python3 -m pip3 install ansible kubernetes jsonpatch PyYAML --ignore-installed
+sudo python3 -m pip install --upgrade pip
+sudo python3 -m pip install cryptography --no-binary --ignore-installed setuptools_rust cryptography
+sudo python3 -m pip install ansible kubernetes jsonpatch PyYAML setuptools --ignore-installed
 ansible-galaxy collection install kubernetes.core
 ansible-playbook yaml/ansible/deploy.yaml

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,5 @@
-sudo dnf install python3 -y
-python3 -m pip install ansible
+sudo dnf install python3 redhat-rpm-config gcc libffi-devel python3-devel openssl-devel cargo pkg-config -y
+python3 -m pip3 install cryptography --no-binary --ignore-installed cryptography
+python3 -m pip3 install ansible kubernetes jsonpatch PyYAML --ignore-installed
 ansible-galaxy collection install kubernetes.core
 ansible-playbook yaml/ansible/deploy.yaml

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,4 @@
+sudo dnf install python3 -y
+python3 -m pip install ansible
+ansible-galaxy collection install kubernetes.core
+ansible-playbook yaml/ansible/deploy.yaml

--- a/yaml/ansible/deploy.yaml
+++ b/yaml/ansible/deploy.yaml
@@ -1,0 +1,69 @@
+- hosts: localhost
+  gather_facts: true
+  become: true
+  vars:
+    ansible_connecton: local
+  environment:
+    KUBECONFIG: "{{ '/home/' if (ansible_user != 'root') else '/'}}{{ ansible_user }}/.kube/config"
+  tasks:
+    - name: Ensure 'kubernetes' pip module is installed.
+      tags: pip
+      ansible.builtin.pip:
+        name: kubernetes
+        state: present
+
+    - name: Create a new project called 'national-parks', if it doesn't already exist.
+      ansible.builtin.shell: oc new-project national-parks || oc project national-parks
+      register: project
+      changed_when: "'AlreadyExists' not in project.stderr"
+
+    - name: Download 'national-parks' manifest from GitHub URL.
+      tags: download
+      ansible.builtin.get_url:
+        url: "https://raw.githubusercontent.com/mmondics/national-parks/main/yaml/combined/national-parks-combined.yaml"
+        dest: ~/national-parks-combined.yaml
+        mode: '0664'
+
+    - name: Deploy the 'national-parks' application from downloaded manifest, wait until complete.
+      tags: deploy
+      kubernetes.core.k8s:
+        state: present
+        namespace: national-parks
+        src: ~/national-parks-combined.yaml
+        wait: True
+
+    - name: Query 'national-parks' pod info for next step.
+      tags: load
+      kubernetes.core.k8s_info:
+        kind: Pod
+        namespace: national-parks
+        label_selectors:
+          - component = nationalparks
+      register: pods
+
+    - name: Load the backend database with data.
+      tags: load
+      ansible.builtin.shell: "oc exec $(oc get pods -l component=nationalparks -n national-parks | tail -n 1 | awk '{print $1;}') -- curl -s http://localhost:8080/ws/data/load"
+
+    - name: Get the 'parksmap' frontend route URL.
+      tags: url
+      kubernetes.core.k8s_info:
+        kind: Route
+        namespace: national-parks
+        name: parksmap
+      register: url
+
+    - name: Get cluster URL for suggestion to put in /etc/hosts in next task.
+      tags: url
+      ansible.builtin.shell: "oc get dns.config.openshift.io/cluster -o jsonpath='{.spec.baseDomain}'"
+      changed_when: false
+      register: cluster_url
+
+    - name: Print instructions and 'parksmap' frontend route URL.
+      tags: url
+      ansible.builtin.debug:
+        msg: |
+          "To access the application from a web browser on your workstation, you will need to first add this line to your /etc/hosts file on your workstation:"
+          "{{ hostvars['localhost'].ipv4_default_ip }} parksmap-national-parks.apps.{{ cluster_url.stdout }} national-parks-national-parks.apps.{{ cluster_url.stdout }}"
+          "Then, open a web browser and go to: http://{{ url.resources[0].spec.host }}"
+          

--- a/yaml/ansible/deploy.yaml
+++ b/yaml/ansible/deploy.yaml
@@ -3,14 +3,25 @@
   become: true
   vars:
     ansible_connecton: local
-  environment:
-    KUBECONFIG: "{{ '/home/' if (ansible_user != 'root') else '/'}}{{ ansible_user }}/.kube/config"
   tasks:
+    - name: Set fact for KUBECONFIG auth.
+      tags: kubeconfig
+      set_fact:
+        KUBECONFIG: "{{ '/home/' if (ansible_user_id != 'root') else '/'}}{{ ansible_user_id }}/.kube/config"
+
+    - name: Get pip path for use in next step.
+      tags: pip
+      ansible.builtin.command: "which pip3"
+      register: pip_path
+      changed_when: false
+
     - name: Ensure 'kubernetes' pip module is installed.
       tags: pip
       ansible.builtin.pip:
         name: kubernetes
         state: present
+        executable: "{{ pip_path.stdout }}"
+        extra_args: --ignore-installed
 
     - name: Create a new project called 'national-parks', if it doesn't already exist.
       ansible.builtin.shell: oc new-project national-parks || oc project national-parks
@@ -21,7 +32,7 @@
       tags: download
       ansible.builtin.get_url:
         url: "https://raw.githubusercontent.com/mmondics/national-parks/main/yaml/combined/national-parks-combined.yaml"
-        dest: ~/national-parks-combined.yaml
+        dest: ./national-parks-combined.yaml
         mode: '0664'
 
     - name: Deploy the 'national-parks' application from downloaded manifest, wait until complete.
@@ -29,7 +40,7 @@
       kubernetes.core.k8s:
         state: present
         namespace: national-parks
-        src: ~/national-parks-combined.yaml
+        src: ./national-parks-combined.yaml
         wait: True
 
     - name: Query 'national-parks' pod info for next step.
@@ -53,7 +64,7 @@
         name: parksmap
       register: url
 
-    - name: Get cluster URL for suggestion to put in /etc/hosts in next task.
+    - name: Get cluster URL for instructions to put in /etc/hosts in next task.
       tags: url
       ansible.builtin.shell: "oc get dns.config.openshift.io/cluster -o jsonpath='{.spec.baseDomain}'"
       changed_when: false
@@ -62,8 +73,8 @@
     - name: Print instructions and 'parksmap' frontend route URL.
       tags: url
       ansible.builtin.debug:
-        msg: |
-          "To access the application from a web browser on your workstation, you will need to first add this line to your /etc/hosts file on your workstation:"
-          "{{ hostvars['localhost'].ipv4_default_ip }} parksmap-national-parks.apps.{{ cluster_url.stdout }} national-parks-national-parks.apps.{{ cluster_url.stdout }}"
-          "Then, open a web browser and go to: http://{{ url.resources[0].spec.host }}"
-          
+        msg:
+          - "To access the application from a web browser on your workstation..."
+          - "You will need to first add this line to your /etc/hosts file on your workstation:"
+          - "{{ ansible_default_ipv4.address }} parksmap-national-parks.apps.{{ cluster_url.stdout }} national-parks-national-parks.apps.{{ cluster_url.stdout }}"
+          - "Then, open a web browser and go to: http://{{ url.resources[0].spec.host }}"


### PR DESCRIPTION
Add the option to deploy the national-parks application via Ansible automation. It requires the user to SSH to their bastion server and run one command (which is comprised of multiple commands, that then kick off a shell script, which then kicks off Ansible).

If you want to try it out, and let me know if there are any missing dependencies - I'll add them. I tested it on my cluster, but not every bastion is the same. Tested on RHEL 8.7 bastion, deployed to OCP 4.13 cluster.